### PR TITLE
Fix depreciation warning with new process.client

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -23,7 +23,7 @@ const strategies = {
 }
 
 export default (ctx, inject) => {
-  const key = ctx.isClient ? 'client' : 'server'
+  const key = process.client ? 'client' : 'server'
   const strategy = strategies[key]
   return strategy(ctx, inject)
 }


### PR DESCRIPTION
Instead of `content.isClient`.