### PR TITLE
fixes #4 - Fix for SPA mode (without server)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,7 +18,11 @@ const strategies = {
   },
 
   client (ctx, inject) {
-    inject('env', ctx.nuxtState.env)
+    try {
+      inject('env', ctx.nuxtState.env)
+    } catch (ex) {
+      inject('env', ctx.env)
+    }
   }
 }
 


### PR DESCRIPTION
Hi everybody,

I'm using Nuxt in several evironments (web, spa, electron, android) and this module is a holy grail for me. But I got a little problem when using this stuff in SPA mode without server-side.

```
[nuxt] Error while initializing app TypeError: Cannot read property 'env' of undefined
    at client (http://127.0.0.1:3000/nuxt/app.js:3575:32)
    at webpackJsonp../.nuxt/lib.plugin.20c53f6a.js.__webpack_exports__.a (http://127.0.0.1:3000/nuxt/app.js:3589:10)
    at _callee2$ (http://127.0.0.1:3000/nuxt/app.js:3282:116)
    at tryCatch (http://127.0.0.1:3000/nuxt/vendor.js:8875:40)
    at Generator.invoke [as _invoke] (http://127.0.0.1:3000/nuxt/vendor.js:9109:22)
    at Generator.prototype.(anonymous function) [as next] (http://127.0.0.1:3000/nuxt/vendor.js:8927:21)
    at step (http://127.0.0.1:3000/nuxt/vendor.js:8483:30)
    at http://127.0.0.1:3000/nuxt/vendor.js:8494:13
    at <anonymous>
```

The problem is comming from plugin.js.

```
client (ctx, inject) {
  inject('env', ctx.nuxtState.env)
}
```

There is not `nuxtState` property on `ctx` when we are in **SPA** mode.

We can use ctx.env in this situation to provide a standard `ctx.app.$env` interface in all application modes.

The fix:
```
// plugin.js

  client (ctx, inject) {
    try {
      inject('env', ctx.nuxtState.env)
    } catch (ex) {
      inject('env', ctx.env)
    }
  }
```