### PR TITLE
update readme setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ yarn add nuxt-env
 // nuxt.config.js
 
 // Tell nuxt-env which env vars you want to inject
-modules: ['nuxt-env', {
-  keys: ['TEST_VALUE']
-}]
+modules: [
+  'other-nuxt-module',
+  ['nuxt-env', {
+    keys: ['TEST_VALUE']
+  }]
+]
 ```
 
 


### PR DESCRIPTION
I spent 30 minutes figuring out how to add this module when other modules have already been added to a Nuxt instance.
i would like to save this trouble for other developers.

i tried to add it like this, which obviously does't work:
```javascript
modules: [
  'other-module',
  'nuxt-env',
  {
    keys: ['TEST_VALUE']
  }
],
```

ps: thanks for this great module 😊