### PR TITLE
Fix the key name of template object (`filename` -> `fileName`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ module.exports = function NuxtEnv ({ keys }) {
   const src = path.resolve(__dirname, 'lib/plugin.js')
   this.addPlugin({
     src,
-    filename: 'nuxt-env'
+    fileName: 'nuxt-env.js'
   })
 }

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,7 @@ describe('Module', () => {
     expect(FakeModule.addPlugin).toHaveBeenCalled()
     const { calls: { 0: { 0: calls } } } = FakeModule.addPlugin.mock
 
-    expect(calls.filename).toEqual('nuxt-env')
+    expect(calls.fileName).toEqual('nuxt-env.js')
     expect(calls.src).toMatch(/lib\/plugin\.js/)
   })
 })


### PR DESCRIPTION
This fix makes the build file name expected. (e.g. `.nuxt/lib.plugin.291fd674.js` -> `.nuxt/nuxt-env.js`)

`addTemplate` which is used by `addPlugin` accepts `fileName` property.
https://nuxtjs.org/api/internals-module-container#addtemplate-template-

Thanks 😊