### PR TITLE
fix: Check if nuxtState.env is defined for SPA

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -22,7 +22,7 @@ const strategies = {
   },
 
   client (ctx, inject) {
-    const env = ctx.nuxtState !== undefined ? ctx.nuxtState.env : ctx.env
+    const env = ctx.nuxtState?.env ? ctx.nuxtState.env : ctx.env
     inject('env', env)
   }
 }


### PR DESCRIPTION
This is related to https://github.com/samtgarson/nuxt-env/pull/8. 

It seems like with the Nuxt v.2.13+ that includes https://nuxtjs.org/guide/runtime-config, nuxtState is still defined for SPAs with the `nuxtState.config` defined with no `nuxtState.env` defined. See below for the error and nuxtState object in SPA mode.

<img width="792" alt="Screen Shot 2020-09-03 at 11 56 15 AM" src="https://user-images.githubusercontent.com/40924388/92066347-9bc21f80-eddc-11ea-8a1e-6c9310a24e9e.png">


